### PR TITLE
Cleaned up problems with the javadoc.

### DIFF
--- a/src/main/java/com/comcast/zucchini/Barrier.java
+++ b/src/main/java/com/comcast/zucchini/Barrier.java
@@ -3,7 +3,7 @@ package com.comcast.zucchini;
 /**
  * This creates a barrier sync when using the Zucchini framework.
  *
- * This must be active under an AbstractZucchiniTest.
+ * This must be active under an {@link AbstractZucchiniTest}.
  *
  * @author Andrew Benton
  */
@@ -13,7 +13,7 @@ public class Barrier {
     }
 
     /**
-     * Creates a barrier sync that will wait until all {@see TestContext}'s join or fail.
+     * Creates a barrier sync that will wait until all {@link TestContext}'s join or fail.
      *
      * @return The order in which the runners are released from the barrier.
      */
@@ -22,7 +22,7 @@ public class Barrier {
     }
 
     /**
-     * Creates a barrier sync that will wait until `milliseconds` after the first TestContext hits the barrier or all {@see TestContext}'s join or fail.
+     * Creates a barrier sync that will wait until <code>milliseconds</code> after the first TestContext hits the barrier or all {@link TestContext}'s join or fail.
      *
      * @param milliseconds The amount of time allocated to wait until the barrier times out and halts non-waiting threads.
      * @return The order in which the runners are released from the barrier.

--- a/src/main/java/com/comcast/zucchini/FlexibleBarrier.java
+++ b/src/main/java/com/comcast/zucchini/FlexibleBarrier.java
@@ -34,16 +34,16 @@ class FlexibleBarrier {
     private int secondaryOrder;
 
     /**
-     * Create a FlexibleBarrier and size it based on the number on contexts in `azt`.
+     * Create a FlexibleBarrier and size it based on the number on contexts in <code>azt</code>.
      */
     FlexibleBarrier(AbstractZucchiniTest azt) {
         this(azt, azt.contexts.size());
     }
 
     /**
-     * Create a FlexibleBarrier and size it based on `size` regardless of what is in `azt`.
+     * Create a FlexibleBarrier and size it based on <code>size</code> regardless of what is in <code>azt</code>.
      *
-     * Future resizing is based on the contents of `azt`
+     * Future resizing is based on the contents of <code>azt</code>
      */
     FlexibleBarrier(AbstractZucchiniTest azt, int size) {
         this.azt = azt;
@@ -95,14 +95,14 @@ class FlexibleBarrier {
     }
 
     /**
-     * Await until all {@see TestContexts} have reached this point or failed.
+     * Await until all {@link TestContexts} have reached this point or failed.
      */
     int await() {
         return this.await(-1);
     }
 
     /**
-     * Await until all {@see TestContext}'s have reached this point, failed, or timedout.
+     * Await until all {@link TestContext}'s have reached this point, failed, or timedout.
      */
     int await(int milliseconds) {
         if(milliseconds == 0) //we aren't waiting, return no positionnal data

--- a/src/main/java/com/comcast/zucchini/ZucchiniInvocationHandler.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniInvocationHandler.java
@@ -19,10 +19,10 @@ class ZucchiniInvocationHandler implements InvocationHandler {
     private Class type;
 
     /**
-     * Create the ZucchiniInvocationHandler so that it calls against `baseProxy` and has the internal class `type`.
+     * Create the ZucchiniInvocationHandler so that it calls against <code>baseProxy</code> and has the internal class <code>type</code>.
      *
      * @param baseProxy The object that will be called when calls are made to this InvocationHandler
-     * @param type The type of class that the `baseProxy` internally represents
+     * @param type The type of class that the <code>baseProxy</code> internally represents
      */
     public ZucchiniInvocationHandler(Object baseProxy, Class type) {
         this.baseProxy = baseProxy;

--- a/src/main/java/com/comcast/zucchini/ZucchiniRuntime.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniRuntime.java
@@ -28,7 +28,7 @@ import gherkin.formatter.model.Step;
 import gherkin.formatter.model.Tag;
 
 /**
- * Extends a wraps cucumber.runtime.Runtime object for Zucchini's extended functionality.
+ * Extends a wraps {@link cucumber.runtime.Runtime} object for Zucchini's extended functionality.
  *
  * @author Andrew Benton
  */
@@ -39,7 +39,12 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
     protected ZucchiniRuntimeOptions ros;
 
     /**
-     * {@inheritDoc}
+     * Creates a sub-zucchini runtime replacing the {@link RuntimeOptions} with {@link ZucchiniRuntimeOptions}, and then links it for all inherited calls.
+     *
+     * @param resourceLoader
+     * @param classFinder
+     * @param classLoader
+     * @param runtimeOptions RuntimeOptions that will be converted to {@link ZucchiniRuntimeOptions} if need be, and then used
      */
     public ZucchiniRuntime(ResourceLoader resourceLoader, ClassFinder classFinder, ClassLoader classLoader, RuntimeOptions runtimeOptions) {
         super(resourceLoader, classFinder, classLoader, runtimeOptions);
@@ -52,7 +57,12 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a sub-zucchini runtime replacing the {@link RuntimeOptions} with {@link ZucchiniRuntimeOptions}, and then links it for all inherited calls.
+     *
+     * @param resourceLoader
+     * @param classLoader
+     * @param backends
+     * @param runtimeOptions RuntimeOptions that will be converted to {@link ZucchiniRuntimeOptions} if need be, and then used
      */
     public ZucchiniRuntime(ResourceLoader resourceLoader, ClassLoader classLoader, Collection<? extends Backend> backends, RuntimeOptions runtimeOptions) {
         super(resourceLoader, classLoader, backends, runtimeOptions);
@@ -65,7 +75,13 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a sub-zucchini runtime replacing the {@link RuntimeOptions} with {@link ZucchiniRuntimeOptions}, and then links it for all inherited calls.
+     *
+     * @param resourceLoader
+     * @param classLoader
+     * @param backends
+     * @param runtimeOptions RuntimeOptions that will be converted to {@link ZucchiniRuntimeOptions} if need be, and then used
+     * @param optionalGlue
      */
     public ZucchiniRuntime(ResourceLoader resourceLoader, ClassLoader classLoader, Collection<? extends Backend> backends, RuntimeOptions runtimeOptions, RuntimeGlue optionalGlue) {
         super(resourceLoader, classLoader, backends,  runtimeOptions, optionalGlue);
@@ -78,7 +94,14 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a sub-zucchini runtime replacing the {@link RuntimeOptions} with {@link ZucchiniRuntimeOptions}, and then links it for all inherited calls.
+     *
+     * @param resourceLoader
+     * @param classLoader
+     * @param backends
+     * @param runtimeOptions RuntimeOptions that will be converted to {@link ZucchiniRuntimeOptions} if need be, and then used
+     * @param stopWatch
+     * @param optionalGlue
      */
     public ZucchiniRuntime(ResourceLoader resourceLoader, ClassLoader classLoader, Collection<? extends Backend> backends, RuntimeOptions runtimeOptions, StopWatch stopWatch, RuntimeGlue optionalGlue) {
         super(resourceLoader, classLoader, backends, runtimeOptions, stopWatch, optionalGlue);
@@ -93,7 +116,7 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
     /**
      * Similar to the inherited version, but adds a check for ThreadDeath from the Barrier.sync().
      *
-     * @param error The error that was thrown by the test and must be registered.  If it wasn't a {@see ThreadDeath}, then this will be checked against a list of already failed contexts.
+     * @param error The error that was thrown by the test and must be registered.  If it wasn't a {@link ThreadDeath}, then this will be checked against a list of already failed contexts.
      */
     @Override
     public void addError(Throwable error) {
@@ -166,7 +189,7 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
     }
 
     /**
-     * This encapsulates the {@link Runtime#runStep} method with a level of safety, and provides information back to the barrier about whether it is safe to kill the running thread.
+     * This encapsulates the {@link cucumber.runtime.Runtime#runStep} method with a level of safety, and provides information back to the barrier about whether it is safe to kill the running thread.
      */
     @Override
     public void runStep(String featurePath, Step step, Reporter reporter, I18n i18n) {

--- a/src/main/java/com/comcast/zucchini/ZucchiniRuntimeOptions.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniRuntimeOptions.java
@@ -18,7 +18,7 @@ import gherkin.formatter.Formatter;
 import gherkin.formatter.Reporter;
 
 /**
- * This is a thin wrapper around RuntimeOptions that allows injection of the {@see ZucchiniInvocationHandler} for future extension of the {@see ZucchiniRuntime}
+ * This is a thin wrapper around RuntimeOptions that allows injection of the {@link ZucchiniInvocationHandler} for future extension of the {@link ZucchiniRuntime}
  *
  * @author Andrew Benton
  */
@@ -26,7 +26,9 @@ public class ZucchiniRuntimeOptions extends RuntimeOptions {
     private RuntimeOptions ros;
 
     /**
-     * {@inheritDoc}
+     * Creates a ZucchiniRuntimeOptions from a string of arguments.
+     *
+     * @param argv The string of arguments
      */
     public ZucchiniRuntimeOptions(String argv) {
         super(argv);
@@ -34,7 +36,9 @@ public class ZucchiniRuntimeOptions extends RuntimeOptions {
     }
 
     /**
-     * {@inheritDoc}
+     * Creates ZucchiniRuntimeOptions from a list of arguments.
+     *
+     * @param argv The list of arguments, already tokenized
      */
     public ZucchiniRuntimeOptions(List<String> argv) {
         super(argv);
@@ -42,7 +46,10 @@ public class ZucchiniRuntimeOptions extends RuntimeOptions {
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a ZucchiniRuntimeOptions from an {@link Env} and a list of arguments.
+     *
+     * @param env The environment to use
+     * @param argv Tokenized list of arguments to use
      */
     public ZucchiniRuntimeOptions(Env env, List<String> argv) {
         super(env, argv);
@@ -50,7 +57,10 @@ public class ZucchiniRuntimeOptions extends RuntimeOptions {
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a ZucchiniRuntimeOptions from a {@link PluginFactory} and a list of arguments.
+     *
+     * @param pluginFactory The pre-created factory that is used to instantiate plugins internally
+     * @param argv The pre-tokenized list of arguments to use
      */
     public ZucchiniRuntimeOptions(PluginFactory pluginFactory, List<String> argv) {
         super(pluginFactory, argv);
@@ -58,7 +68,11 @@ public class ZucchiniRuntimeOptions extends RuntimeOptions {
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a ZucchiniRuntimeOptions from a {@link Env}, a {@link PluginFactory}, and a list of arguments
+     *
+     * @param env Environment to create the runtime options in
+     * @param pluginFactory The pre-created factory that is used to instantiate plugins internally
+     * @param argv The tokenized list of arguments
      */
     public ZucchiniRuntimeOptions(Env env, PluginFactory pluginFactory, List<String> argv) {
         super(env, pluginFactory, argv);
@@ -66,7 +80,11 @@ public class ZucchiniRuntimeOptions extends RuntimeOptions {
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a ZucchiniRuntimeOptions from a {@link RuntimeOptions}.
+     *
+     * For this operation, all inherited methods punch through to the passed runtime options, and overridden access to the pluginProxy does internal access here before reaching the underlying RuntimeOptions
+     *
+     * @param ros The RuntimeOptions that is used for most calls.
      */
     public ZucchiniRuntimeOptions(RuntimeOptions ros) {
         super(""); //wasted option


### PR DESCRIPTION
Problems included incompatibility between @see and @link, as well as
replacing back ticks with <code />.  Additionally, some of the @inheritDoc
annotations were removed where they were not appropriate.  Certain
functions still need to have javadoc more fleshed out because Cucumber
does not have most of their public API documented inline.
