### PR TITLE
Disabled bsync function by default, added function to enable it.

### DIFF
--- a/src/main/java/com/comcast/zucchini/AbstractZucchiniTest.java
+++ b/src/main/java/com/comcast/zucchini/AbstractZucchiniTest.java
@@ -56,6 +56,9 @@ public abstract class AbstractZucchiniTest {
     /* flexible barrier for test-wise locking */
     FlexibleBarrier flexBarrier;
 
+    private boolean canBarrier = false;       //can be set anytime and only takes effect for the next run
+    private boolean canBarrierInTest = false; //cached before the test begins to prevent undefined behavior
+
     private void genHook() {
         if(hooked)
             return;
@@ -81,6 +84,18 @@ public abstract class AbstractZucchiniTest {
     @AfterClass
     public void generateReports() {
         //this does nothing now, left for API consistency
+    }
+
+    public boolean getCanBarrier() {
+        return this.canBarrier;
+    }
+
+    public boolean getCanBarrierInTest() {
+        return this.canBarrierInTest;
+    }
+
+    public void setCanBarrier(boolean canBarrier) {
+        this.canBarrier = canBarrier;
     }
 
     /**
@@ -132,6 +147,8 @@ public abstract class AbstractZucchiniTest {
      * @param contexts The list of contexts that will be run.
      */
     public void runParallel(List<TestContext> contexts) {
+        this.canBarrierInTest = this.canBarrier;
+
         List<Thread> threads = new ArrayList<Thread>(contexts.size());
 
         MutableInt mi = new MutableInt();
@@ -164,6 +181,8 @@ public abstract class AbstractZucchiniTest {
      * @param contexts The list of contexts that will be run.
      */
     public void runSerial(List<TestContext> contexts) {
+        this.canBarrierInTest = this.canBarrier;
+
         int failures = 0;
 
         for(TestContext tc : contexts)

--- a/src/main/java/com/comcast/zucchini/AbstractZucchiniTest.java
+++ b/src/main/java/com/comcast/zucchini/AbstractZucchiniTest.java
@@ -56,9 +56,6 @@ public abstract class AbstractZucchiniTest {
     /* flexible barrier for test-wise locking */
     FlexibleBarrier flexBarrier;
 
-    private boolean canBarrier = false;       //can be set anytime and only takes effect for the next run
-    private boolean canBarrierInTest = false; //cached before the test begins to prevent undefined behavior
-
     private void genHook() {
         if(hooked)
             return;
@@ -84,18 +81,6 @@ public abstract class AbstractZucchiniTest {
     @AfterClass
     public void generateReports() {
         //this does nothing now, left for API consistency
-    }
-
-    public boolean getCanBarrier() {
-        return this.canBarrier;
-    }
-
-    public boolean getCanBarrierInTest() {
-        return this.canBarrierInTest;
-    }
-
-    public void setCanBarrier(boolean canBarrier) {
-        this.canBarrier = canBarrier;
     }
 
     /**
@@ -147,8 +132,6 @@ public abstract class AbstractZucchiniTest {
      * @param contexts The list of contexts that will be run.
      */
     public void runParallel(List<TestContext> contexts) {
-        this.canBarrierInTest = this.canBarrier;
-
         List<Thread> threads = new ArrayList<Thread>(contexts.size());
 
         MutableInt mi = new MutableInt();
@@ -181,8 +164,6 @@ public abstract class AbstractZucchiniTest {
      * @param contexts The list of contexts that will be run.
      */
     public void runSerial(List<TestContext> contexts) {
-        this.canBarrierInTest = this.canBarrier;
-
         int failures = 0;
 
         for(TestContext tc : contexts)
@@ -351,5 +332,16 @@ public abstract class AbstractZucchiniTest {
      */
     public void setupFormatter(TestContext out, TestNGZucchiniRunner runner) {
         LOGGER.debug("Setup formatter method was not implemented for " + this.getClass().getSimpleName());
+    }
+
+    /**
+     * Tell the test whether it can use a barrier or not.
+     *
+     * The value that this function returns should not change after a test has been started, or it will result in undefined behavior.  It may change while no tests are running.
+     *
+     * @return Whether this test allows barrier synchronization
+     */
+    public boolean canBarrier() {
+        return false;
     }
 }

--- a/src/main/java/com/comcast/zucchini/Barrier.java
+++ b/src/main/java/com/comcast/zucchini/Barrier.java
@@ -35,6 +35,9 @@ public class Barrier {
 
         AbstractZucchiniTest azt = tc.getParentTest();
 
+        if(!azt.getCanBarrierInTest())
+            throw new ZucchiniRuntimeException("This test is not configured to allow barriers.");
+
         if(azt.isParallel())
             return azt.flexBarrier.await(milliseconds);
         else

--- a/src/main/java/com/comcast/zucchini/Barrier.java
+++ b/src/main/java/com/comcast/zucchini/Barrier.java
@@ -35,7 +35,7 @@ public class Barrier {
 
         AbstractZucchiniTest azt = tc.getParentTest();
 
-        if(!azt.getCanBarrierInTest())
+        if(!azt.canBarrier())
             throw new ZucchiniRuntimeException("This test is not configured to allow barriers.");
 
         if(azt.isParallel())

--- a/src/main/java/com/comcast/zucchini/ZucchiniRuntime.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniRuntime.java
@@ -162,20 +162,22 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
 
             for(CucumberTagStatement statement : cf.getFeatureElements()) {
 
-                if(azt.isParallel())
-                    order = azt.phase0.await();
-                else
-                    order = 0;
+                if(azt.getCanBarrierInTest()) {
+                    if(azt.isParallel())
+                        order = azt.phase0.await();
+                    else
+                        order = 0;
 
-                //reset the lock and scenario state
-                if(order == 0) {
-                    //clear configuration here for per-scenario state
-                    azt.failedContexts.clear();
-                    azt.flexBarrier.refresh();
+                    //reset the lock and scenario state
+                    if(order == 0) {
+                        //clear configuration here for per-scenario state
+                        azt.failedContexts.clear();
+                        azt.flexBarrier.refresh();
+                    }
+
+                    if(azt.isParallel())
+                        order = azt.phase1.await();
                 }
-
-                if(azt.isParallel())
-                    order = azt.phase1.await();
 
                 statement.run(formatter, reporter, this);
             }

--- a/src/main/java/com/comcast/zucchini/ZucchiniRuntime.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniRuntime.java
@@ -127,7 +127,7 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
         //if the error was not caused by a barrier timeout
         if(!(error instanceof ThreadDeath)) {
             AbstractZucchiniTest azt = tc.getParentTest();
-            if(azt.getCanBarrierInTest()) {
+            if(azt.canBarrier()) {
                 if(!azt.failedContexts.contains(tc)) {
                     synchronized(azt.failedContexts) {
                         if(!azt.failedContexts.contains(tc)) {
@@ -164,7 +164,7 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
 
             for(CucumberTagStatement statement : cf.getFeatureElements()) {
 
-                if(azt.getCanBarrierInTest()) {
+                if(azt.canBarrier()) {
                     if(azt.isParallel())
                         order = azt.phase0.await();
                     else

--- a/src/main/java/com/comcast/zucchini/ZucchiniRuntime.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniRuntime.java
@@ -125,7 +125,6 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
         TestContext tc = TestContext.getCurrent();
 
         //if the error was not caused by a barrier timeout
-        if(
         if(!(error instanceof ThreadDeath)) {
             AbstractZucchiniTest azt = tc.getParentTest();
             if(azt.getCanBarrierInTest()) {

--- a/src/main/java/com/comcast/zucchini/ZucchiniRuntime.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniRuntime.java
@@ -125,13 +125,16 @@ public class ZucchiniRuntime extends cucumber.runtime.Runtime {
         TestContext tc = TestContext.getCurrent();
 
         //if the error was not caused by a barrier timeout
+        if(
         if(!(error instanceof ThreadDeath)) {
             AbstractZucchiniTest azt = tc.getParentTest();
-            if(!azt.failedContexts.contains(tc)) {
-                synchronized(azt.failedContexts) {
-                    if(!azt.failedContexts.contains(tc)) {
-                        azt.failedContexts.add(tc);
-                        azt.flexBarrier.dec();
+            if(azt.getCanBarrierInTest()) {
+                if(!azt.failedContexts.contains(tc)) {
+                    synchronized(azt.failedContexts) {
+                        if(!azt.failedContexts.contains(tc)) {
+                            azt.failedContexts.add(tc);
+                            azt.flexBarrier.dec();
+                        }
                     }
                 }
             }

--- a/src/main/java/com/comcast/zucchini/ZucchiniRuntimeException.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniRuntimeException.java
@@ -1,0 +1,9 @@
+package com.comcast.zucchini;
+
+import java.lang.RuntimeException;
+
+public class ZucchiniRuntimeException extends RuntimeException {
+    public ZucchiniRuntimeException(String msg) {
+        super(msg);
+    }
+}

--- a/src/test/java/com/comcast/zucchini/BarrierTest.java
+++ b/src/test/java/com/comcast/zucchini/BarrierTest.java
@@ -18,6 +18,8 @@ public class BarrierTest extends AbstractZucchiniTest {
 
     @Override
     public List<TestContext> getTestContexts() {
+        this.setCanBarrier(true);
+
         List<TestContext> contexts = new ArrayList<TestContext>();
 
         for(int i = 0; i < numContexts; i++) {

--- a/src/test/java/com/comcast/zucchini/BarrierTest.java
+++ b/src/test/java/com/comcast/zucchini/BarrierTest.java
@@ -18,8 +18,6 @@ public class BarrierTest extends AbstractZucchiniTest {
 
     @Override
     public List<TestContext> getTestContexts() {
-        this.setCanBarrier(true);
-
         List<TestContext> contexts = new ArrayList<TestContext>();
 
         for(int i = 0; i < numContexts; i++) {
@@ -27,5 +25,10 @@ public class BarrierTest extends AbstractZucchiniTest {
         }
 
         return contexts;
+    }
+
+    @Override
+    public boolean canBarrier() {
+        return true;
     }
 }


### PR DESCRIPTION
By default, barrier sync functionality is disabled by default with the PR.  By calling setCanBarrier(), the barrier sync can be re-enabled on a test-wise level.  In the case that the barrier sync is not enabled for a test, and one of that test's glue functions calls Barrier.sync(), Zucchini will throw a ZucchiniRuntimeException. 
