### PR TITLE
Add zucchini version to title of test.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,19 @@
                     </executions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.comcast.zucchini</groupId>
     <artifactId>zucchini</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <name>(${project.organization.name}) ${project.artifactId}</name>
 
     <licenses>
@@ -144,6 +144,29 @@
                         </manifest>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+                <executions>
+                    <execution>
+                        <id>Version Transform</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/classes</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/comcast/zucchini/AbstractZucchiniTest.java
+++ b/src/main/java/com/comcast/zucchini/AbstractZucchiniTest.java
@@ -85,7 +85,7 @@ public abstract class AbstractZucchiniTest {
 
         /* add a shutdown hook, as this will allow all Zucchini tests to complete without
          * knowledge of each other's existence */
-        Runtime.getRuntime().addShutdownHook(new ZucchiniShutdownHook());
+        Runtime.getRuntime().addShutdownHook(ZucchiniShutdownHook.getDefault());
     }
 
     /**
@@ -207,6 +207,14 @@ public abstract class AbstractZucchiniTest {
         try {
             setup(context);
             setupFormatter(context, runner);
+        } catch (RuntimeException rex) {
+            String errString = String.format("ERROR configuring test: {}", rex);
+            LOGGER.error(errString);
+            ZucchiniShutdownHook.getDefault().addFailureCause(errString);
+            return false;
+        }
+
+        try {
             runner.runCukes();
             ret = true;
         } catch (RuntimeException t) {
@@ -267,8 +275,10 @@ public abstract class AbstractZucchiniTest {
             try {
                 cleanup(context);
             }
-            catch(Throwable t) {
-                LOGGER.error("ERROR: {}", t);
+            catch(RuntimeException rex) {
+                String errString = String.format("ERROR cleaning up test: {}", rex);
+                LOGGER.error(errString);
+                ZucchiniShutdownHook.getDefault().addFailureCause(errString);
             }
 
             TestContext.removeCurrent();

--- a/src/main/java/com/comcast/zucchini/AbstractZucchiniTest.java
+++ b/src/main/java/com/comcast/zucchini/AbstractZucchiniTest.java
@@ -264,7 +264,13 @@ public abstract class AbstractZucchiniTest {
                 }
             }
 
-            cleanup(context);
+            try {
+                cleanup(context);
+            }
+            catch(Throwable t) {
+                LOGGER.error("ERROR: {}", t);
+            }
+
             TestContext.removeCurrent();
         }
 

--- a/src/main/java/com/comcast/zucchini/ZucchiniShutdownHook.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniShutdownHook.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 class ZucchiniShutdownHook extends Thread {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ZucchiniShutdownHook.class);
+    private static final String NAME_ENV_VAR = "ZUCCHINI_REPORT_NAME";
 
     private static ZucchiniShutdownHook instance = null;
 
@@ -85,13 +86,13 @@ class ZucchiniShutdownHook extends Thread {
 
                 if(version == null) {
                     try {
-                        InputStream ips = this.getClass().getClassLoader().getResourceAsStream("META-INF/MANIFEST.MF");
+                        InputStream ips = this.getClass().getClassLoader().getResourceAsStream("version.properties");
 
                         if(ips != null) {
                             Properties props = new Properties();
                             props.load(ips);
 
-                            version = props.getProperty("Implementation-version");
+                            version = props.getProperty("version");
                         }
                     }
                     catch(IOException ioe) {
@@ -104,7 +105,13 @@ class ZucchiniShutdownHook extends Thread {
                 else
                     version = " - Zucchini (" + version + ")";
 
-                ReportBuilder reportBuilder = new ReportBuilder(pathList, html, "", "1" + version, "Zucchini" + version, true, true, true, false, false, "", false);
+                String rptName = "${" + NAME_ENV_VAR + "}";
+
+                if(System.getenv(NAME_ENV_VAR) != null)
+                    rptName = System.getenv(NAME_ENV_VAR);
+
+
+                ReportBuilder reportBuilder = new ReportBuilder(pathList, html, "", rptName + version, "Zucchini" + version, true, true, true, false, false, "", false);
                 reportBuilder.generateReports();
 
                 boolean buildResult = reportBuilder.getBuildStatus();

--- a/src/main/java/com/comcast/zucchini/ZucchiniShutdownHook.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniShutdownHook.java
@@ -138,12 +138,13 @@ class ZucchiniShutdownHook extends Thread {
             StringBuilder sb = new StringBuilder();
 
             int idx = 0;
+
+            sb.append("Zucchini failed with the following errors:\n");
             for(String cause : this.zucchiniFailureCauses) {
                 sb.append(String.format("Cause[%3d] :: %s\n", idx++, cause));
             }
 
-            System.out.println("Zucchini failed with the following errors:");
-            System.out.print(sb.toString());
+            LOGGER.error(sb.toString());
 
             Runtime.getRuntime().halt(-1);
         }

--- a/src/main/java/com/comcast/zucchini/ZucchiniShutdownHook.java
+++ b/src/main/java/com/comcast/zucchini/ZucchiniShutdownHook.java
@@ -17,10 +17,12 @@ package com.comcast.zucchini;
 
 import java.util.List;
 import java.util.LinkedList;
+import java.util.Properties;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 
 import com.google.gson.JsonArray;
 
@@ -56,7 +58,31 @@ class ZucchiniShutdownHook extends Thread {
 
                 List<String> pathList = new LinkedList<String>();
                 pathList.add(json.getAbsolutePath());
-                ReportBuilder reportBuilder = new ReportBuilder(pathList, html, "", "1", "Zucchini", true, true, true, false, false, "", false);
+
+                String version = this.getClass().getPackage().getImplementationVersion();
+
+                if(version == null) {
+                    try {
+                        InputStream ips = this.getClass().getClassLoader().getResourceAsStream("META-INF/MANIFEST.MF");
+
+                        if(ips != null) {
+                            Properties props = new Properties();
+                            props.load(ips);
+
+                            version = props.getProperty("Implementation-version");
+                        }
+                    }
+                    catch(IOException ioe) {
+                        LOGGER.warn("{}", ioe);
+                    }
+                }
+
+                if(version == null)
+                    version = "";
+                else
+                    version = " - Zucchini (" + version + ")";
+
+                ReportBuilder reportBuilder = new ReportBuilder(pathList, html, "", "1" + version, "Zucchini" + version, true, true, true, false, false, "", false);
                 reportBuilder.generateReports();
 
                 boolean buildResult = reportBuilder.getBuildStatus();

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${project.version}


### PR DESCRIPTION
Title of the zucchini test output was always "1" before.  Now it at least provides some useful output.  This will help in identifying what version is actually being used and resolved by the POM so that debugging and error reporting is more accurate. 
