### PR TITLE
Replaced Thread.stop(ex) with arg-less version.

### DIFF
--- a/src/main/java/com/comcast/zucchini/FlexibleBarrier.java
+++ b/src/main/java/com/comcast/zucchini/FlexibleBarrier.java
@@ -126,7 +126,8 @@ class FlexibleBarrier {
         TestContext tc = TestContext.getCurrent();
 
         if(this.azt.failedContexts.contains(tc)) {
-            Thread.currentThread().stop(new IllegalStateException("Failed context has somehow continued."));
+            LOGGER.debug("Failed context, {}, that has continued has been terminated.", tc);
+            Thread.currentThread().stop();
         }
 
         synchronized(this) {


### PR DESCRIPTION
The parameterized function causes problems when interrupting improperly
continuing threads.  Instead of wrapping the illegal state exception,
this prints a log message and then uses Thread.stop() to kill the
thread.
