### PR TITLE
Re-create the Phasers on reset to avoid bad state.  Add test for all-context failure pattern.

### DIFF
--- a/src/test/java/com/comcast/zucchini/BarrierFailureTest.java
+++ b/src/test/java/com/comcast/zucchini/BarrierFailureTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2014 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.comcast.zucchini;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+
+import cucumber.api.CucumberOptions;
+
+@CucumberOptions(
+    glue = {"com.comcast.zucchini.glue"},
+    features = {"src/test/resources"},
+    tags = {"@BARRIER-FAILURE"}
+    )
+@ZucchiniOutput()
+public class BarrierFailureTest extends AbstractZucchiniTest {
+
+    public static int numContexts = 3;
+
+    @Override
+    public List<TestContext> getTestContexts() {
+        List<TestContext> contexts = new ArrayList<TestContext>();
+
+        for(int i = 0; i < numContexts; i++) {
+            Map<String, Object> map = new HashMap<String, Object>();
+            map.put("idx", new Integer(i));
+            contexts.add(new TestContext(String.format("ThreadIdx[%d]", i), map));
+        }
+
+        return contexts;
+    }
+
+    @Override
+    public boolean canBarrier() {
+        return true;
+    }
+}

--- a/src/test/java/com/comcast/zucchini/glue/ZucchiniBarrierFailureGlue.java
+++ b/src/test/java/com/comcast/zucchini/glue/ZucchiniBarrierFailureGlue.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2014 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.comcast.zucchini.glue;
+
+import org.testng.Assert;
+
+import com.comcast.zucchini.Barrier;
+import com.comcast.zucchini.TestContext;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ZucchiniBarrierFailureGlue {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZucchiniBarrierFailureGlue.class);
+
+    private static final String FF_ENV_NAME = "ZUCCHINI_TEST_FF_PATTERNS";
+
+    @Given("we barrier in the init")
+    public void background_init() {
+        LOGGER.debug("Background init");
+
+        Integer i = (Integer)TestContext.getCurrent().get("idx");
+
+        try {
+            Thread.sleep(i);
+        }
+        catch(InterruptedException iex) {
+            LOGGER.error("Failed to sleep: ", iex);
+        }
+    }
+
+    @Given("we run this step")
+    public void given_step() {
+        LOGGER.debug("Scenario setup");
+        Barrier.sync();
+    }
+
+    @Then("we fail here")
+    public void fail_here() throws Throwable {
+        String ztffp = System.getenv(ZucchiniBarrierFailureGlue.FF_ENV_NAME);
+        if(ztffp == null)
+            ztffp = "0";
+
+        if(("1").equals(ztffp))
+            Assert.fail("FORCE ALL CONTEXT TEST FAILURE");
+        else
+            Thread.sleep(100);
+    }
+
+    @Then("we don\'t fail")
+    public void pass_here() {
+        LOGGER.debug("No failure for this scenario.");
+    }
+}

--- a/src/test/java/com/comcast/zucchini/glue/ZucchiniBarrierFailureGlue.java
+++ b/src/test/java/com/comcast/zucchini/glue/ZucchiniBarrierFailureGlue.java
@@ -57,10 +57,10 @@ public class ZucchiniBarrierFailureGlue {
         if(ztffp == null)
             ztffp = "0";
 
-        if(("1").equals(ztffp))
+        if(("1").equals(ztffp)) {
+            Barrier.sync();
             Assert.fail("FORCE ALL CONTEXT TEST FAILURE");
-        else
-            Thread.sleep(100);
+        }
     }
 
     @Then("we don\'t fail")

--- a/src/test/resources/zucchini-cf.feature
+++ b/src/test/resources/zucchini-cf.feature
@@ -1,0 +1,12 @@
+@SMOKE-TEST @BARRIER-FAILURE
+Feature: Zucchini must be able to continue after all contexts fail on a scenario
+    Background:
+        Given we barrier in the init
+
+    Scenario:
+        Given we run this step
+        Then we fail here
+
+    Scenario:
+        Given we run this step
+        Then we don't fail


### PR DESCRIPTION
Certain tests could cause a problem with Zucchini when all contexts failed, which put the phaser into a bad state.  To avoid this problem the phasers are re-created on each reset.  The provided test should emulate the failure pattern, but will only cause the failure pattern when the ZUCCHINI_TEST_FF_PATTERNS environment variable is set to "1"
