### PR TITLE
Upgrade to net.masterthought:cucumber-reporting:3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <slf4j.version>1.6.4</slf4j.version>
         <logback.version>1.1.2</logback.version>
         <cucumber.version>1.2.4</cucumber.version>
-        <cucumber.reporting.version>0.0.23</cucumber.reporting.version>
+        <cucumber.reporting.version>3.2.0</cucumber.reporting.version>
         <testng.version>6.8.8</testng.version>
 
         <!-- Plugin Versions -->

--- a/src/test/java/com/comcast/zucchini/FastrunZucchiniCukesTest.java
+++ b/src/test/java/com/comcast/zucchini/FastrunZucchiniCukesTest.java
@@ -105,12 +105,10 @@ class FastrunZucchiniCukesTest extends AbstractZucchiniTest {
     public Iterator<CucumberFeatureHolder> fastrunIteratorFactory(Iterator<CucumberFeature> iterator) {
         Iterator<CucumberFeatureHolder> response = super.fastrunIteratorFactory(iterator);
 
-        if (null == singleton) {
-            synchronized (this) {
-                if (null == singleton) {
-                    singleton = response;
-                    wrapped = new TestIterator<CucumberFeatureHolder>(response);
-                }
+        synchronized (this) {
+            if (null == singleton) {
+                singleton = response;
+                wrapped = new TestIterator<CucumberFeatureHolder>(response);
             }
         }
         Assert.assertTrue(singleton == response, "The iterators returned from fastrun should be the same one as it is a singleton");


### PR DESCRIPTION
Hey @trentontrees can you take a look at this?

We were dealing with an issue with zucchini where net.masterthought:cucumber-reporting was pulling in dependency com.googlecode.totallylazy:totallylazy, which I guess is not in maven central.

Looks like later version of cucumber-reporting does not have this dependency. We were already using a very old version 0.2.3, over 4 years old. So this is to update the reports that gets generated for zucchini.